### PR TITLE
Fixed wrong contract bug in foreign call functions

### DIFF
--- a/src/modules/rules-engine.ts
+++ b/src/modules/rules-engine.ts
@@ -754,7 +754,7 @@ export class RulesEngine {
    *
    * @param foreignCallAddress - the address of the contract the foreign call belongs to.
    * @param functionSelector - The selector for the specific foreign call
-   * @param policyAdminsToAdd - The address of the admins to add to the list
+   * @param policyAdminsToAdd - The addresses of the admins to add to the list
    * @returns A promise that resolves to a number:
    *          - `0` if the operation is successful.
    *          - `-1` if an error occurs during the simulation of the contract interaction.


### PR DESCRIPTION
Looks like there were a couple of foreign call functions that didn't get updated to use the correct contract. This was causing ABI not found errors in the FRE UI server.