### PR TITLE
RL-359 Added more validation and tests

### DIFF
--- a/src/modules/validation.ts
+++ b/src/modules/validation.ts
@@ -207,6 +207,7 @@ const validateReferencedCalls = (input: any): boolean => {
 
   const callingFunctionNames = input.CallingFunctions.map((call: any) => call.name);
   const fcCallingFunctions: string[] = input.ForeignCalls.map((fc: any) => fc.callingFunction);
+
   if (!fcCallingFunctions.every((fcName) => callingFunctionNames.includes(fcName))) {
     return false;
   }
@@ -257,10 +258,7 @@ export const validateCondition = (condition: string): boolean => {
     .map(validateConditionGroup)
     .every((isValid) => isValid);
 
-  if (!validatedOperators) return false; // If any group is invalid, return false
-
-
-  return true;
+  return validatedOperators;
 }
 
 
@@ -561,7 +559,7 @@ export const policyJSONValidator = z.object({
   Trackers: z.array(trackerValidator),
   MappedTrackers: z.array(mappedTrackerValidator),
   Rules: z.array(ruleValidator),
-});
+}).refine(validateReferencedCalls, { message: "Invalid reference call" });
 export interface PolicyJSON extends z.infer<typeof policyJSONValidator> { }
 
 /**

--- a/src/parsing/parser.ts
+++ b/src/parsing/parser.ts
@@ -210,17 +210,17 @@ export function parseRuleSyntax(
   var raw = buildRawData(retVal, excludeArray);
   positiveEffectsFinal.forEach(
     (effect) =>
-      (effect.instructionSet = buildRawData(
-        effect.instructionSet,
-        excludeArray
-      ))
+    (effect.instructionSet = buildRawData(
+      effect.instructionSet,
+      excludeArray
+    ))
   );
   negativeEffectsFinal.forEach(
     (effect) =>
-      (effect.instructionSet = buildRawData(
-        effect.instructionSet,
-        excludeArray
-      ))
+    (effect.instructionSet = buildRawData(
+      effect.instructionSet,
+      excludeArray
+    ))
   );
   return {
     instructionSet: raw,

--- a/src/parsing/reverse-parsing-logic.ts
+++ b/src/parsing/reverse-parsing-logic.ts
@@ -578,6 +578,7 @@ export function convertForeignCallStructsToStrings(
       const callingFunction = callingFunctionMappings.find(
         (mapping) => mapping.index == call.callingFunctionIndex
       );
+      console.log("CFCSTS functionMeta", functionMeta);
       const inputs = {
         name: functionMeta?.functionString || "",
         address: call.foreignCallAddress as Address,

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -1220,55 +1220,55 @@ describe("Rules Engine Interactions", async () => {
   });
   test("Can check if a policy exists", async () => {
     var policyJSON = `
-            {
-            "Policy": "Test Policy",
-            "Description": "Test Policy Description",
-            "PolicyType": "open",
-            "CallingFunctions": [
-              {
-                "name": "transfer(address to, uint256 value)",
-                "functionSignature": "transfer(address to, uint256 value)",
-                "encodedValues": "address to, uint256 value"
-              }
-            ],
-            "ForeignCalls": [
-            {
-                    "name": "testSigTwo(uint256)",
-                    "address": "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
-                    "function": "testSigTwo(uint256)",
-                    "returnType": "uint256",
-                    "valuesToPass": "TR:mTrackerOne",
-                    "mappedTrackerKeyValues": "to",
-                    "callingFunction": "transfer(address to, uint256 value)"
-            },{
-                    "name": "testSig(address)",
-                    "address": "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
-                    "function": "testSig(uint256)",
-                    "returnType": "uint256",
-                    "valuesToPass": "FC:testSigTwo",
-                    "mappedTrackerKeyValues": "",
-                    "callingFunction": "transfer(address to, uint256 value)"
-                }
-            ],
-            "Trackers": [
-            {
-                "name": "Simple String Tracker",
-                "type": "string",
-                "initialValue": "test"
-            }
-            ],
-            "MappedTrackers": [],
-            "Rules": [
-                {
-                    "Name": "Rule A",
-                    "Description": "Rule A Description",
-                    "condition": "value > 500",
-                    "positiveEffects": ["emit Success"],
-                    "negativeEffects": ["revert()"],
-                    "callingFunction": "transfer(address to, uint256 value)"
-                }
-                ]
-                }`;
+      {
+      "Policy": "Test Policy",
+      "Description": "Test Policy Description",
+      "PolicyType": "open",
+      "CallingFunctions": [
+        {
+          "name": "transfer(address to, uint256 value)",
+          "functionSignature": "transfer(address to, uint256 value)",
+          "encodedValues": "address to, uint256 value"
+        }
+      ],
+      "ForeignCalls": [
+      {
+              "name": "testSigTwo",
+              "address": "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
+              "function": "testSigTwo(uint256)",
+              "returnType": "uint256",
+              "valuesToPass": "TR:SimpleStringTracker",
+              "mappedTrackerKeyValues": "to",
+              "callingFunction": "transfer(address to, uint256 value)"
+      },{
+              "name": "testSig(address)",
+              "address": "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
+              "function": "testSig(uint256)",
+              "returnType": "uint256",
+              "valuesToPass": "FC:testSigTwo",
+              "mappedTrackerKeyValues": "",
+              "callingFunction": "transfer(address to, uint256 value)"
+          }
+      ],
+      "Trackers": [
+      {
+          "name": "SimpleStringTracker",
+          "type": "string",
+          "initialValue": "test"
+      }
+      ],
+      "MappedTrackers": [],
+      "Rules": [
+          {
+              "Name": "Rule A",
+              "Description": "Rule A Description",
+              "condition": "value > 500",
+              "positiveEffects": ["emit Success"],
+              "negativeEffects": ["revert()"],
+              "callingFunction": "transfer(address to, uint256 value)"
+          }
+          ]
+          }`;
     var result = await createPolicy(
       config,
       getRulesEnginePolicyContract(rulesEngineContract, client),

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -1052,7 +1052,7 @@ describe("Rules Engine Interactions", async () => {
                ],
                "ForeignCalls": [
                  {
-                     "name": "AnotherTestForeignCall(address)",
+                     "name": "AnotherTestForeignCall",
                      "address": "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
                      "function": "AnotherTestForeignCall(address)",
                      "returnType": "uint256",
@@ -1061,9 +1061,9 @@ describe("Rules Engine Interactions", async () => {
                      "callingFunction": "transfer(address to, uint256 value)"
                  },
                  {
-                     "name": "ATestForeignCall(address,uint256)",
+                     "name": "ATestForeignCall",
                      "address": "0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC",
-                     "function": "ATestForeignCall(address,uint256)",
+                     "function": "ATestForeignCall(address, uint256)",
                      "returnType": "uint256",
                      "valuesToPass": "FC:AnotherTestForeignCall, TR:trackerOne",
                      "mappedTrackerKeyValues": "",
@@ -1130,27 +1130,14 @@ describe("Rules Engine Interactions", async () => {
     );
 
     const parsed = JSON.parse(retVal);
+    console.log("Parsed Policy:", parsed);
 
     const input = JSON.parse(policyJSON);
+    // TODOupdate the input to match known limitations with the reverse parser
+    input.ForeignCalls[0].function = input.ForeignCalls[0].name;
+    input.ForeignCalls[1].function = input.ForeignCalls[1].name;
 
-    input.ForeignCalls[0].function = "AnotherTestForeignCall(address)";
-    input.ForeignCalls[1].function = "ATestForeignCall(address,uint256)";
-    input.ForeignCalls[0].valuesToPass = "to";
-    input.ForeignCalls[0].callingFunction =
-      "transfer(address to, uint256 value)";
-    input.ForeignCalls[1].valuesToPass =
-      "FC:AnotherTestForeignCall, TR:trackerOne";
-    input.ForeignCalls[1].callingFunction =
-      "transfer(address to, uint256 value)";
-    input.Rules[0].negativeEffects = [
-      "revert('Negative')",
-      "TRU:trackerOne += 12",
-    ];
-    input.Rules[0].positiveEffects = [
-      "emit Success",
-      "FC:AnotherTestForeignCall",
-      "TRU:mappedTrackerOne(to) += 1",
-    ];
+    input.Rules[0].negativeEffects[0] = "revert('Negative')";
 
     expect(parsed.Policy).toEqual(input.Policy);
     expect(retVal).toEqual(JSON.stringify(input, null, 2));


### PR DESCRIPTION
- add validation for rule conditions
   - all parenthesis groups are well formatted with a pair of parenthesis surrounding 3 parts with  1 AND or OR in the middle position
   
- add validation for referenced calls for ForeignCalls, Trackers, Mapped Trackers, and Calling Function encodedValues
   -all referenced calls are defined

** Does Not Support Mapped Trackers as arguments for Mapped Trackers