### PR TITLE
RL-426 inject security override into user contract

### DIFF
--- a/src/codeGeneration/template.ts
+++ b/src/codeGeneration/template.ts
@@ -11,10 +11,5 @@ pragma solidity ^0.8.24;
  *              for modifiers that are generated and injected programmatically.
  */
 abstract contract RulesEngineClientCustom is RulesEngineClient {
-    /**
-     * @notice This function overrides a function in the RulesEngineClient and must be updated for successful compilation.
-     */
-    function setCallingContractAdmin(address callingContractAdmin) public {}
-
     // Modifier Here
 }`

--- a/tests/code-generation.test.ts
+++ b/tests/code-generation.test.ts
@@ -1,7 +1,7 @@
 /// SPDX-License-Identifier: BUSL-1.1
 import { expect, test } from 'vitest'
 import { generateModifier } from '../src/codeGeneration/generate-solidity'
-import { injectModifier } from '../src/codeGeneration/inject-modifier'
+import { contractHasSecurityOverride, injectModifier } from '../src/codeGeneration/inject-modifier'
 import * as fs from 'fs'
 import { policyModifierGeneration } from '../src/codeGeneration/code-modification-script'
 
@@ -84,4 +84,17 @@ test('Code Generation test)', () => {
 
     expect(data.includes('setCallingContractAdmin(')).toBeTruthy()
   })
+})
+
+test('Security override detection', () => {
+  const singleLineDeclaration = 'function setCallingContractAdmin(address callingContractAdmin) public {})'
+  const multiLineDeclaration = 'function setCallingContractAdmin(address callingContractAdmin) public {})'
+
+  const singleLineDetected = contractHasSecurityOverride(singleLineDeclaration)
+  const multiLineDetected = contractHasSecurityOverride(multiLineDeclaration)
+  const noDeclarationDetected = contractHasSecurityOverride('function someOtherFunction() public {}')
+
+  expect(singleLineDetected).toBe(true)
+  expect(multiLineDetected).toBe(true)
+  expect(noDeclarationDetected).toBe(false)
 })

--- a/tests/code-generation.test.ts
+++ b/tests/code-generation.test.ts
@@ -13,7 +13,6 @@ test('Code Modification test)', () => {
       console.error('Error reading file:', err)
       return
     }
-    console.log(data)
 
     expect(data.includes('checkRulesBeforetransfer(')).toBeTruthy()
   })

--- a/tests/code-generation.test.ts
+++ b/tests/code-generation.test.ts
@@ -86,8 +86,9 @@ test('Code Generation test)', () => {
 })
 
 test('Security override detection', () => {
-  const singleLineDeclaration = 'function setCallingContractAdmin(address callingContractAdmin) public {})'
-  const multiLineDeclaration = 'function setCallingContractAdmin(address callingContractAdmin) public {})'
+  const singleLineDeclaration = 'function setCallingContractAdmin(address callingContractAdmin) public {}'
+  const multiLineDeclaration = `function setCallingContractAdmin(address callingContractAdmin) public {
+  }`
 
   const singleLineDetected = contractHasSecurityOverride(singleLineDeclaration)
   const multiLineDetected = contractHasSecurityOverride(multiLineDeclaration)

--- a/tests/code-generation.test.ts
+++ b/tests/code-generation.test.ts
@@ -1,29 +1,25 @@
 /// SPDX-License-Identifier: BUSL-1.1
-import { expect, test } from "vitest";
-import { generateModifier } from "../src/codeGeneration/generate-solidity";
-import { injectModifier } from "../src/codeGeneration/inject-modifier";
-import * as fs from "fs";
-import { policyModifierGeneration } from "../src/codeGeneration/code-modification-script";
+import { expect, test } from 'vitest'
+import { generateModifier } from '../src/codeGeneration/generate-solidity'
+import { injectModifier } from '../src/codeGeneration/inject-modifier'
+import * as fs from 'fs'
+import { policyModifierGeneration } from '../src/codeGeneration/code-modification-script'
 
-test("Code Modification test)", () => {
-  policyModifierGeneration(
-    "./tests/testPolicy.json",
-    "./tests/testOutput/TestContract.sol",
-    []
-  );
+test('Code Modification test)', () => {
+  policyModifierGeneration('./tests/testPolicy.json', './tests/testOutput/TestContract.sol', [])
 
-  fs.readFile("tests/testOutput/TestContract.sol", "utf-8", (err, data) => {
+  fs.readFile('tests/testOutput/TestContract.sol', 'utf-8', (err, data) => {
     if (err) {
-      console.error("Error reading file:", err);
-      return;
+      console.error('Error reading file:', err)
+      return
     }
-    console.log(data);
+    console.log(data)
 
-    expect(data.includes("checkRulesBeforetransfer(")).toBeTruthy();
-  });
-});
+    expect(data.includes('checkRulesBeforetransfer(')).toBeTruthy()
+  })
+})
 
-test("Code Generation test)", () => {
+test('Code Generation test)', () => {
   const policyJSON = `
         {
         "Policy": "Test Policy",
@@ -65,25 +61,27 @@ test("Code Generation test)", () => {
                 "callingFunction": "transfer(address to, uint256 value)"
             }
         ]
-        }`;
+        }`
 
-  generateModifier(policyJSON, "tests/testOutput/testFileA.sol");
+  generateModifier(policyJSON, 'tests/testOutput/testFileA.sol')
   injectModifier(
-    "transfer",
-    "address to, uint256 value, uint256 somethinElse",
-    "tests/testOutput/UserContract.sol",
-    "tests/testOutput/diff.diff",
-    "tests/testOutput/testFileA.sol"
-  );
-  expect(fs.existsSync("tests/testOutput/diff.diff")).toBeTruthy();
-  expect(fs.existsSync("tests/testOutput/testFileA.sol")).toBeTruthy();
+    'transfer',
+    'address to, uint256 value, uint256 somethinElse',
+    'tests/testOutput/UserContract.sol',
+    'tests/testOutput/diff.diff',
+    'tests/testOutput/testFileA.sol'
+  )
+  expect(fs.existsSync('tests/testOutput/diff.diff')).toBeTruthy()
+  expect(fs.existsSync('tests/testOutput/testFileA.sol')).toBeTruthy()
 
-  fs.readFile("tests/testOutput/UserContract.sol", "utf-8", (err, data) => {
+  fs.readFile('tests/testOutput/UserContract.sol', 'utf-8', (err, data) => {
     if (err) {
-      console.error("Error reading file:", err);
-      return;
+      console.error('Error reading file:', err)
+      return
     }
 
-    expect(data.includes("checkRulesBeforetransfer(")).toBeTruthy();
-  });
-});
+    expect(data.includes('checkRulesBeforetransfer(')).toBeTruthy()
+
+    expect(data.includes('setCallingContractAdmin(')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
- removed security override from, `template.sol`
- inject security override into user contract
- added test for injected override
- added support for rules engine inheritance already included in the user contract