### PR TITLE
RL-526 RL-527 RL-528 RL-529 refined types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,12 +12,9 @@ export { policyModifierGeneration } from './codeGeneration/code-modification-scr
 
 export { getTrackerToRuleIds } from './modules/trackers.js'
 
-export { 
-  createCallingFunctionLookupMaps,
-  resolveCallingFunction,
-} from './modules/validation.js'
+export { createCallingFunctionLookupMaps, resolveCallingFunction } from './modules/validation.js'
 
-export { 
+export {
   createPolicy,
   updatePolicy,
   setPolicies,
@@ -36,7 +33,7 @@ export {
   addClosedPolicySubscriber,
   removeClosedPolicySubscriber,
   cementPolicy,
-  isCementedPolicy
+  isCementedPolicy,
 } from './modules/policy.js'
 
 export {
@@ -49,8 +46,6 @@ export {
   RuleStruct,
   ForeignCallDefinition,
   PlaceholderStruct,
-  IndividualArgumentMapping as IndividualArugmentMapping,
-  ForeignCallArgumentMappings,
   FunctionArgument,
   stringReplacement,
   trackerIndexNameMapping,

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export {
 export {
   RulesEnginePolicyContract,
   RulesEngineComponentContract,
-  FCNameToID,
+  NameToID,
   RuleStorageSet,
   hexToFunctionString,
   EffectType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,6 @@ export {
   PlaceholderStruct,
   FunctionArgument,
   stringReplacement,
-  trackerIndexNameMapping,
   TrackerDefinition,
   RawData,
   RuleData,

--- a/src/modules/contract-interaction-utils.ts
+++ b/src/modules/contract-interaction-utils.ts
@@ -6,7 +6,7 @@ import { parseRuleSyntax, cleanInstructionSet, buildForeignCallList, buildTracke
 import {
   EffectStruct,
   EffectStructs,
-  FCNameToID,
+  NameToID,
   Maybe,
   RulesEngineAdminABI,
   RulesEngineAdminContract,
@@ -114,9 +114,9 @@ export async function sleep(ms: number): Promise<void> {
  */
 export function buildARuleStruct(
   ruleSyntax: RuleJSON,
-  foreignCallNameToID: FCNameToID[],
+  foreignCallNameToID: NameToID[],
   effect: EffectStructs,
-  trackerNameToID: FCNameToID[],
+  trackerNameToID: NameToID[],
   encodedValues: string,
   additionalForeignCalls: string[],
   additionalEffectForeignCalls: string[]
@@ -174,8 +174,8 @@ export function buildARuleStruct(
  */
 export function buildAnEffectStruct(
   ruleSyntax: RuleJSON,
-  trackerNameToID: FCNameToID[],
-  foreignCallNameToID: FCNameToID[],
+  trackerNameToID: NameToID[],
+  foreignCallNameToID: NameToID[],
   encodedValues: string,
   additionalForeignCalls: string[],
   additionalEffectForeignCalls: string[]

--- a/src/modules/foreign-calls.ts
+++ b/src/modules/foreign-calls.ts
@@ -8,7 +8,7 @@ import {
   RulesEngineComponentContract,
   Maybe,
   TrackerOnChain,
-  FCNameToID,
+  NameToID,
   RulesEnginePolicyContract,
   RulesEngineForeignCallContract,
   TrackerMetadataStruct,
@@ -88,7 +88,7 @@ export const createForeignCall = async (
     getTrackerMetadata(config, rulesEngineComponentContract, policyId, tracker.trackerIndex)
   )
   const trackerMetadata = await Promise.all(trackerMetadataCalls)
-  const trackerMap: FCNameToID[] = trackerMetadata.map((name: TrackerMetadataStruct, index: number) => {
+  const trackerMap: NameToID[] = trackerMetadata.map((name: TrackerMetadataStruct, index: number) => {
     return {
       name: name.trackerName,
       id: trackers[index].trackerIndex,
@@ -100,9 +100,9 @@ export const createForeignCall = async (
   const foreignCallMetadataCalls = foreignCalls.map((fc) =>
     getForeignCallMetadata(config, rulesEngineForeignCallContract, policyId, fc.foreignCallIndex)
   )
-  var fcMap: FCNameToID[] = []
+  var fcMap: NameToID[] = []
   const foreignCallMetadata = await Promise.all(foreignCallMetadataCalls)
-  const fcMapAdditions: FCNameToID[] = foreignCallMetadata.map((nameData: ForeignCallMetadataStruct, index: number) => {
+  const fcMapAdditions: NameToID[] = foreignCallMetadata.map((nameData: ForeignCallMetadataStruct, index: number) => {
     const extractedName = nameData.name.split('(')[0] || `UnknownFC_${index}`
 
     return {
@@ -237,7 +237,7 @@ export const updateForeignCall = async (
     getTrackerMetadata(config, rulesEngineComponentContract, policyId, tracker.trackerIndex)
   )
   const trackerMetadata = await Promise.all(trackerMetadataCalls)
-  const trackerMap: FCNameToID[] = trackerMetadata.map((name: TrackerMetadataStruct, index: number) => {
+  const trackerMap: NameToID[] = trackerMetadata.map((name: TrackerMetadataStruct, index: number) => {
     return {
       name: name.trackerName,
       id: trackers[index].trackerIndex,
@@ -249,9 +249,9 @@ export const updateForeignCall = async (
   const foreignCallMetadataCalls = foreignCalls.map((fc) =>
     getForeignCallMetadata(config, rulesEngineForeignCallContract, policyId, fc.foreignCallIndex)
   )
-  var fcMap: FCNameToID[] = []
+  var fcMap: NameToID[] = []
   const foreignCallMetadata = await Promise.all(foreignCallMetadataCalls)
-  const fcMapAdditions: FCNameToID[] = foreignCallMetadata.map((nameData: ForeignCallMetadataStruct, index: number) => {
+  const fcMapAdditions: NameToID[] = foreignCallMetadata.map((nameData: ForeignCallMetadataStruct, index: number) => {
     // nameData is now always a string from getForeignCallMetadata
     const extractedName = nameData.name || `UnknownFC_${index}`
     return { name: extractedName, id: foreignCalls[index].foreignCallIndex, type: 0 }

--- a/src/modules/policy.ts
+++ b/src/modules/policy.ts
@@ -13,7 +13,7 @@ import {
 import {
   RulesEnginePolicyContract,
   RulesEngineComponentContract,
-  FCNameToID,
+  NameToID,
   ForeignCallOnChain,
   TrackerOnChain,
   hexToFunctionString,
@@ -95,8 +95,8 @@ export const createPolicy = async (
   confirmationCount: number,
   policySyntax?: string
 ): Promise<{ policyId: number }> => {
-  var fcIds: FCNameToID[] = []
-  var trackerIds: FCNameToID[] = []
+  var fcIds: NameToID[] = []
+  var trackerIds: NameToID[] = []
   let ruleIds = []
   let ruleToCallingFunction = new Map<string, number[]>()
   let callingFunctions: string[] = []
@@ -199,7 +199,7 @@ export const createPolicy = async (
           confirmationCount
         )
         if (trId != -1) {
-          var struc: FCNameToID = {
+          var struc: NameToID = {
             id: trId,
             name: parsedTracker.name,
             type: parsedTracker.type,
@@ -221,7 +221,7 @@ export const createPolicy = async (
           confirmationCount
         )
         if (trId != -1) {
-          var struc: FCNameToID = {
+          var struc: NameToID = {
             id: trId,
             name: parsedTracker.name,
             type: parsedTracker.valueType,
@@ -262,7 +262,7 @@ export const createPolicy = async (
 
           // Only add successfully created foreign calls to the mapping
           if (fcId !== -1) {
-            var struc: FCNameToID = {
+            var struc: NameToID = {
               id: fcId,
               name: fcStruct.name.split('(')[0],
               type: 0,

--- a/src/modules/rules-engine.ts
+++ b/src/modules/rules-engine.ts
@@ -23,7 +23,7 @@
 
 import { Address, getContract } from 'viem'
 import {
-  FCNameToID,
+  NameToID,
   CallingFunctionHashMapping,
   RulesEngineComponentABI,
   RulesEngineComponentContract,
@@ -459,8 +459,8 @@ export class RulesEngine {
   createNewRule(
     policyId: number,
     ruleS: string,
-    foreignCallNameToID: FCNameToID[],
-    trackerNameToID: FCNameToID[]
+    foreignCallNameToID: NameToID[],
+    trackerNameToID: NameToID[]
   ): Promise<number> {
     return createRuleInternal(
       config,
@@ -491,8 +491,8 @@ export class RulesEngine {
     policyId: number,
     ruleId: number,
     ruleS: string,
-    foreignCallNameToID: FCNameToID[],
-    trackerNameToID: FCNameToID[]
+    foreignCallNameToID: NameToID[],
+    trackerNameToID: NameToID[]
   ): Promise<number> {
     return updateRuleInternal(
       config,

--- a/src/modules/rules.ts
+++ b/src/modules/rules.ts
@@ -117,7 +117,7 @@ export const createRule = async (
     }
     iter += 1
   }
-  var fcList = await buildForeignCallList(ruleSyntax.condition)
+  var fcList = buildForeignCallList(ruleSyntax.condition)
   var fullFCList = []
   for (var fc of fcList) {
     for (var id of foreignCallNameToID) {

--- a/src/modules/rules.ts
+++ b/src/modules/rules.ts
@@ -4,7 +4,7 @@ import { simulateContract, waitForTransactionReceipt, writeContract, readContrac
 
 import { buildAnEffectStruct, buildARuleStruct, sleep } from './contract-interaction-utils'
 import {
-  FCNameToID,
+  NameToID,
   RuleStruct,
   RuleStorageSet,
   Maybe,
@@ -70,8 +70,8 @@ export const createRule = async (
   rulesEngineForeignCallContract: RulesEngineForeignCallContract,
   policyId: number,
   ruleS: string,
-  foreignCallNameToID: FCNameToID[],
-  trackerNameToID: FCNameToID[],
+  foreignCallNameToID: NameToID[],
+  trackerNameToID: NameToID[],
   confirmationCount: number
 ): Promise<number> => {
   const validatedRuleSyntax = validateRuleJSON(ruleS)
@@ -264,8 +264,8 @@ export const updateRule = async (
   policyId: number,
   ruleId: number,
   ruleS: string,
-  foreignCallNameToID: FCNameToID[],
-  trackerNameToID: FCNameToID[],
+  foreignCallNameToID: NameToID[],
+  trackerNameToID: NameToID[],
   confirmationCount: number
 ): Promise<number> => {
   const validatedRuleSyntax = validateRuleJSON(ruleS)

--- a/src/modules/trackers.ts
+++ b/src/modules/trackers.ts
@@ -359,16 +359,15 @@ export const getTrackerMetadata = async (
   blockParams?: ContractBlockParameters
 ): Promise<TrackerMetadataStruct> => {
   try {
-    const getMeta = await readContract(config, {
+    const getMeta = (await readContract(config, {
       address: rulesEngineComponentContract.address,
       abi: rulesEngineComponentContract.abi,
       functionName: 'getTrackerMetadata',
       args: [policyId, trackerId],
       ...blockParams,
-    })
+    })) as TrackerMetadataStruct
 
-    let foreignCallResult = getMeta as TrackerMetadataStruct
-    return foreignCallResult
+    return getMeta
   } catch (error) {
     console.error(error)
     return {

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -79,12 +79,12 @@ export function convertToVersionStruct(str: string): versionStruct {
 }
 
 /**
- * Maps foreign call or (mapped) tacker names to their IDs
+ * Maps foreign call or (mapped) tracker names to their IDs
  */
-export type FCNameToID = {
-  /** Unique identifier for the foreign call */
+export type NameToID = {
+  /** Unique identifier for the foreign call or tracker */
   id: number
-  /** Name of the foreign call */
+  /** Name of the foreign call or tracker */
   name: string
   /** Type identifier */
   type: number

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -79,7 +79,7 @@ export function convertToVersionStruct(str: string): versionStruct {
 }
 
 /**
- * Maps foreign call names to their IDs
+ * Maps foreign call or (mapped) tacker names to their IDs
  */
 export type FCNameToID = {
   /** Unique identifier for the foreign call */
@@ -328,6 +328,18 @@ export type CallingFunctionOnChain = {
   parameterTypes: number[]
 }
 
+/**
+ * Function argument representation in rule components
+ */
+export type FunctionArgument = {
+  /** Name of the argument */
+  name: string
+  /** Type index */
+  tIndex: number
+  /** Raw type identifier */
+  rawType: string
+}
+
 // -----------------------------------------------------------------------------
 // Foreign Call Types
 // -----------------------------------------------------------------------------
@@ -387,33 +399,9 @@ export type ForeignCallEncodedIndex = {
 }
 
 /**
- * Mapping for individual function arguments
- */
-export type IndividualArgumentMapping = {
-  /** Type of the function call argument */
-  functionCallArgumentType: number
-  /** Argument from the calling function */
-  callingFunctionArg: PlaceholderStruct
-}
-
-/**
- * Mappings for foreign call arguments
- */
-export type ForeignCallArgumentMappings = {
-  /** Index of the foreign call */
-  foreignCallIndex: number
-  /** List of argument mappings */
-  mappings: IndividualArgumentMapping[]
-}
-
-/**
  * Foreign call representation in rule components
  */
-export type ForeignCall = {
-  /** Name of the foreign call */
-  name: string
-  /** Type index */
-  tIndex: number
+export type ForeignCallArgument = FunctionArgument & {
   /** Raw type identifier */
   rawType: 'foreign call'
   /** Placeholder for the foreign call */
@@ -514,11 +502,7 @@ export type MappedTrackerDefinition = {
 /**
  * Tracker representation in rule components
  */
-export type Tracker = {
-  /** Name of the tracker */
-  name: string
-  /** Type index */
-  tIndex: number
+export type TrackerArgument = FunctionArgument & {
   /** Raw type identifier */
   rawType: 'tracker'
   /** Secondary raw type information */
@@ -564,21 +548,9 @@ export type PlaceholderStruct = {
 }
 
 /**
- * Function argument representation in rule components
- */
-export type FunctionArgument = {
-  /** Name of the argument */
-  name: string
-  /** Type index */
-  tIndex: number
-  /** Raw type identifier */
-  rawType: string
-}
-
-/**
  * Union type for components in rules
  */
-export type RuleComponent = FunctionArgument | ForeignCall | Tracker
+export type RuleComponent = FunctionArgument | ForeignCallArgument | TrackerArgument
 
 /**
  * Represents a string replacement in an instruction set

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -456,18 +456,6 @@ export type TrackerMetadataStruct = {
 }
 
 /**
- * Maps tracker indices to names
- */
-export type trackerIndexNameMapping = {
-  /** ID of the tracker */
-  id: number
-  /** Name of the tracker */
-  name: string
-  /** Type of the tracker */
-  type: number
-}
-
-/**
  * Definition of a tracker
  */
 export type TrackerDefinition = {

--- a/src/parsing/internal-parsing-logic.ts
+++ b/src/parsing/internal-parsing-logic.ts
@@ -1,7 +1,7 @@
 /// SPDX-License-Identifier: BUSL-1.1
 import { isAddress } from 'viem'
 import {
-  FCNameToID,
+  NameToID,
   PlaceholderStruct,
   matchArray,
   truMatchArray,
@@ -62,7 +62,7 @@ var originalDelimiters: string[] = []
 export function convertHumanReadableToInstructionSet(
   syntax: string,
   names: any[],
-  trackerNameToID: FCNameToID[],
+  trackerNameToID: NameToID[],
   existingPlaceHolders: PlaceholderStruct[]
 ): InstructionSet {
   //Replace AND, OR and NOT with a placeholder value (PLA) so we can parse them simultaneously
@@ -147,7 +147,7 @@ function convertASTToInstructionSet(
   expression: any[],
   parameterNames: any[],
   placeHolders: PlaceholderStruct[],
-  trackerNameToID: FCNameToID[]
+  trackerNameToID: NameToID[]
 ): ASTAccumulator {
   if (typeof expression[0] == 'string') {
     var foundMatch = false

--- a/src/parsing/parser.ts
+++ b/src/parsing/parser.ts
@@ -10,7 +10,7 @@ import {
 } from 'viem'
 import {
   EffectDefinition,
-  FCNameToID,
+  NameToID,
   ForeignCallDefinition,
   ForeignCallEncodedIndex,
   MappedTrackerDefinition,
@@ -70,8 +70,8 @@ import tr from 'zod/v4/locales/tr.cjs'
 
 export function processSyntax(
   encodedValues: string,
-  foreignCallNameToID: FCNameToID[],
-  trackerNameToID: FCNameToID[],
+  foreignCallNameToID: NameToID[],
+  trackerNameToID: NameToID[],
   additionalForeignCalls: string[],
   syntax: string
 ): [string, RuleComponent[]] {
@@ -94,8 +94,8 @@ export function processSyntax(
 
 function getProcessedEffects(
   encodedValues: string,
-  foreignCallNameToID: FCNameToID[],
-  trackerNameToID: FCNameToID[],
+  foreignCallNameToID: NameToID[],
+  trackerNameToID: NameToID[],
   additionalEffectForeignCalls: string[],
   effects: string[]
 ): Maybe<[EffectDefinition[], PlaceholderStruct[]]> {
@@ -143,8 +143,8 @@ function getProcessedEffects(
 
 export function parseRuleSyntax(
   syntax: RuleJSON,
-  trackerNameToID: FCNameToID[],
-  foreignCallNameToID: FCNameToID[],
+  trackerNameToID: NameToID[],
+  foreignCallNameToID: NameToID[],
   encodedValues: string,
   additionalForeignCalls: string[],
   additionalEffectForeignCalls: string[]
@@ -379,8 +379,8 @@ export function parseTrackerSyntax(syntax: TrackerJSON): TrackerDefinition {
 }
 
 export function getFCEncodedIndex(
-  foreignCallNameToID: FCNameToID[],
-  trackerNameToID: FCNameToID[],
+  foreignCallNameToID: NameToID[],
+  trackerNameToID: NameToID[],
   functionArguments: string[],
   encodedIndex: string
 ): Maybe<ForeignCallEncodedIndex> {
@@ -415,8 +415,8 @@ export function getFCEncodedIndex(
  */
 export function parseForeignCallDefinition(
   syntax: ForeignCallJSON,
-  foreignCallNameToID: FCNameToID[],
-  trackerNameToID: FCNameToID[],
+  foreignCallNameToID: NameToID[],
+  trackerNameToID: NameToID[],
   functionArguments: string[]
 ): ForeignCallDefinition {
   // Validate that the foreign call doesn't reference itself

--- a/src/parsing/parsing-utilities.ts
+++ b/src/parsing/parsing-utilities.ts
@@ -1,7 +1,7 @@
 /// SPDX-License-Identifier: BUSL-1.1
 import { encodeAbiParameters, isAddress, keccak256, parseAbiParameters } from 'viem'
 import {
-  FCNameToID,
+  NameToID,
   EffectType,
   PlaceholderStruct,
   operandArray,
@@ -75,7 +75,7 @@ export function parseFunctionArguments(encodedValues: string, condition?: string
 export function parseTrackers(
   condition: string,
   names: any[],
-  trackerNameToID: FCNameToID[]
+  trackerNameToID: NameToID[]
 ): [string, TrackerArgument[]] {
   const trRegex = /TR:[a-zA-Z]+/g
   const truRegex = /TRU:[a-zA-Z]+/g
@@ -186,8 +186,8 @@ export function parseGlobalVariables(condition: string): RuleComponent[] {
 export function parseForeignCalls(
   condition: string,
   names: any[],
-  foreignCallNameToID: FCNameToID[],
-  trackerNameToID: FCNameToID[],
+  foreignCallNameToID: NameToID[],
+  trackerNameToID: NameToID[],
   additionalForeignCalls: string[]
 ): [string, RuleComponent[]] {
   // Use a regular expression to find all FC expressions
@@ -402,7 +402,7 @@ export function parseEffect(
   effect: string,
   names: any[],
   placeholders: PlaceholderStruct[],
-  trackerNameToID: FCNameToID[]
+  trackerNameToID: NameToID[]
 ): Maybe<EffectDefinition> {
   var effectType = EffectType.REVERT
   var effectText = ''

--- a/src/parsing/parsing-utilities.ts
+++ b/src/parsing/parsing-utilities.ts
@@ -8,7 +8,7 @@ import {
   operandArray,
   EffectDefinition,
   FunctionArgument,
-  Tracker,
+  TrackerArgument,
   RuleComponent,
   PTNamesTracker,
   Maybe,
@@ -77,7 +77,7 @@ export function parseTrackers(
   condition: string,
   names: any[],
   indexMap: trackerIndexNameMapping[]
-): [string, Tracker[]] {
+): [string, TrackerArgument[]] {
   const trRegex = /TR:[a-zA-Z]+/g
   const truRegex = /TRU:[a-zA-Z]+/g
 
@@ -98,7 +98,7 @@ export function parseTrackers(
     return acc.replace(match, initialSplit + ' | ' + match.split('(')[0])
   }, condition)
 
-  const trackers: Tracker[] = matches.map((name) => {
+  const trackers: TrackerArgument[] = matches.map((name) => {
     let rawTypeTwo = 'address'
     let tIndex = 0
     const tracker = indexMap.find((index) => 'TR:' + index.name == name)
@@ -126,8 +126,8 @@ export function parseTrackers(
 
   const updateMatchesSet = [...new Set([...(condition.match(truRegex) || [])])]
 
-  const updatedTrackers: Tracker[] = updateMatchesSet
-    .map((name: string): Maybe<Tracker> => {
+  const updatedTrackers: TrackerArgument[] = updateMatchesSet
+    .map((name: string): Maybe<TrackerArgument> => {
       let tIndex = 0
       name = name.replace('TRU:', 'TR:')
       const tracker = indexMap.find((index) => 'TR:' + index.name == name)


### PR DESCRIPTION
- removed unused types 
- renamed type `Tracker` and `ForeignCal` to `TrackerArgument` and `ForeignCallArgument` and inherited from `FunctionArgument`
- refactored duplicated calling function find loops into separate functions `{create|update}ForeignCalls 
- updated `indexMap` to `trackerNameToID` reflecting its similarity to `foreignCallNameToID`
- refactored `FCNameToID` and `trackerIndexNameMapping` to `NameToID`
-  includes ticket RL-526,527,528,529